### PR TITLE
Compiler issue on Swift 5

### DIFF
--- a/Sources/Emoji.swift
+++ b/Sources/Emoji.swift
@@ -9863,6 +9863,9 @@ public enum Emoji: CaseIterable {
             return ["receipt"]
         case .nazar_amulet:
             return ["nazar_amulet"]
+        default: // <-- warning: Default will never be executed: should be suppressed
+//        default:
+            fatalError()
         }
     }
 
@@ -17201,6 +17204,8 @@ public enum Emoji: CaseIterable {
             return ["\u{1f9fe}"]
         case .nazar_amulet:
             return ["\u{1f9ff}"]
+        default:
+            fatalError()
         }
     }
 

--- a/tools/gen-emoji-swift.py
+++ b/tools/gen-emoji-swift.py
@@ -93,6 +93,10 @@ shortnames_var = '''
 print(shortnames_var)
 for emoji in emojis:
     pshortname(emoji[0], emoji[1])
+default_case_var = '''        default:
+            fatalError()'''
+
+print(default_case_var)
 
 print('        }')
 print('    }')
@@ -105,6 +109,7 @@ print(codepoints_var)
 for emoji in emojis:
     pcodepoints(emoji[0], emoji[2])
 
+print(default_case_var)
 print('        }')
 print('    }')
 print('''


### PR DESCRIPTION
So...

I'm not really happy with the solution but it's working.
On the latest Xcode ß, it's impossible to build without triggering an error
<img width="512" alt="Capture d’écran, le 2019-06-26 à 16 57 25" src="https://user-images.githubusercontent.com/968830/60215182-0f5db980-9835-11e9-9973-a0436383d3af.png">

So I just added a default case and well... Seems to do the trick...
We just have a warning because obviously the default is here for nothing.

I'm not sure this is a regression from the Swift compiler. For sure, we are doing something heavy here but still.
I'll let you judge this issue, if you should open one on Swift repo or not 