### PR TITLE
Add watchOS deployment target to the podspec

### DIFF
--- a/Emoji-swift.podspec
+++ b/Emoji-swift.podspec
@@ -11,5 +11,6 @@ Pod::Spec.new do |s|
   s.framework    = 'Foundation'
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.9"
+  s.watchos.deployment_target = "5.0"
   s.requires_arc = true
 end


### PR DESCRIPTION
Hi There,

Thanks very much for Emoji-Swift, would be great to use it on watchOS in addition to iOS, have added the watchos deployment target to the podspec, and can confirm everything building here with Xcode 11.

Cheers